### PR TITLE
fix: Se regenera el .env para el enpoint principal

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:3000/api/v1

--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,6 @@ dist-ssr
 .vscode/*
 !.vscode/extensions.json
 .idea
-.env
 .DS_Store
 *.suo
 *.ntvs*


### PR DESCRIPTION
# Cambios
- No se genero correctamente el .env en la carpeta raiz y se quito del `.gitignore`
- Se hizo el fix desde el #11 