### PR TITLE
feat: Se deja estructura lista del sidebar y contenido central

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,3 +1,31 @@
-export const Sidebar = () => {
-  return <div>Sidebar</div>;
+import { useAuthStore } from "@/store/authStore";
+import { v } from "@/styles/variables";
+
+interface SidebarProps {
+  sidebarOpen: boolean;
+  setSidebarOpen: () => void;
+}
+
+export const Sidebar = ({ sidebarOpen, setSidebarOpen }: SidebarProps) => {
+  const { logout } = useAuthStore();
+  return (
+    <div
+      className={`h-screen ${sidebarOpen ? "w-64 max-w-full" : "w-16 max-w-full"} bg-neutral transition-all duration-300`}
+    >
+      <div
+        className={`flex justify-center items-center text-white text-3xl ${sidebarOpen ? "block" : "hidden"}`}
+      >
+        <img src={v.logoLogin} className="w-14" />
+      </div>
+      <button onClick={logout} className="btn btn-secondary text-white">
+        Logout
+      </button>
+      <button
+        onClick={setSidebarOpen}
+        className="btn btn-secondary top-4 right-4 text-white bg-gray-800 p-2 rounded-full"
+      >
+        {sidebarOpen ? "Close" : "Open"}
+      </button>
+    </div>
+  );
 };

--- a/src/components/ui/Icon.tsx
+++ b/src/components/ui/Icon.tsx
@@ -6,7 +6,7 @@ interface IconProps {
   className?: string;
 }
 
-export const Icon: React.FC<IconProps> = ({ name, size, className = "" }) => {
+export const Icon = ({ name, size, className = "" }: IconProps) => {
   const IconComponent = v[name];
 
   if (!IconComponent) return null;

--- a/src/pages/PrivateRoutes/Home.tsx
+++ b/src/pages/PrivateRoutes/Home.tsx
@@ -1,18 +1,44 @@
-import { useContext } from "react";
+import { Sidebar } from "@/components/Sidebar";
 
-import { Navbar } from "@components/Navbar";
+import { useContext, useState } from "react";
+
 import { AuthContext } from "@context/AuthContext";
 
 export const Home = () => {
+  const [sidebarOpen, setSidebarOpen] = useState<boolean>(false);
   const authContext = useContext(AuthContext);
   const user = authContext?.user;
   return (
-    <div>
-      <Navbar />
-      <code>{user?.id}</code>
-      <h1>Bienvenido, {user?.nameUser || "Invitado"}!</h1>
-      <h2>Tu correo es, {user?.email} </h2>
-      <h3>Tu role es {user?.role} </h3>
+    <div className="flex h-full">
+      {/* Sidebar */}
+      <Sidebar
+        sidebarOpen={sidebarOpen}
+        setSidebarOpen={() => setSidebarOpen(!sidebarOpen)}
+      />{" "}
+      {/* Ajusta el ancho del sidebar según sea necesario */}
+      {/* Contenido principal */}
+      <div className="flex flex-col items-center justify-start w-full bg-[theme('colors.bgtotal')] text-[theme('colors.text')]">
+        {/* Area 1 */}
+        <section className="bg-[rgba(229,67,26,0.14)] flex items-center justify-center w-full h-1/4">
+          <code>{user?.id}</code>
+        </section>
+
+        {/* Area 2 */}
+        <section className="bg-[rgba(77,237,106,0.14)] flex items-center justify-center w-full h-1/4">
+          <h1>Bienvenido, {user?.nameUser || "Invitado"}!</h1>
+        </section>
+
+        {/* Area 2 */}
+        <section className="bg-[rgba(77,160,237,0.14)] flex items-center justify-center w-full h-1/4">
+          <h1>Bienvenido, {user?.nameUser || "Invitado"}!</h1>
+        </section>
+
+        {/* Main */}
+        <section className="bg-[rgba(179,46,241,0.14)] p-4 w-full h-1/4">
+          <h2>Tu correo es, {user?.email} </h2>
+          <h3>Tu role es {user?.role} </h3>
+        </section>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
# Cambios
- Se arregla las dimensiones del sidebar y de las secciones que ocupara cada pagina con el formato de grid
- Se pone la funcion de abrir el sidebar y cerrarlo, y el boton de logout para cverrar la sesion sin necesidad de borrar el token del localStorage